### PR TITLE
New radar image URL

### DIFF
--- a/arsoapi/models.py
+++ b/arsoapi/models.py
@@ -22,7 +22,7 @@ import osgeo.gdalconst as gdalc
 # set to 1 to print out stuff
 LOG_LEVEL = getattr(settings, 'LOG_LEVEL', 0)
 
-URL_VREME_RADAR = 'http://www.arso.gov.si/vreme/napovedi%20in%20podatki/radar.gif'
+URL_VREME_RADAR = 'http://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm.gif'
 URL_VREME_TOCA  = 'http://www.meteo.si/uploads/probase/www/warning/graphic/warning_%s_hp_si.jpg'
 #URL_VREME_ALADIN = 'http://www.arso.gov.si/vreme/napovedi%%20in%%20podatki/aladin/AW00_oblpad_%.3d.png'
 URL_VREME_ALADIN = 'http://meteo.arso.gov.si/uploads/probase/www/model/aladin/field/as_%s-%s_tcc-rr_si-neighbours_%.3d.png'


### PR DESCRIPTION
I don't know if that's the only problem that's causing the instance running on opendata.si to return 500 errors. Running the code locally I can't find any other problems right now.

As far as radar data is concerned, I think only the URL changed. The format of the image stayed the same and the "new" color scheme was already added in #4.